### PR TITLE
Add Org Collection Themes link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,3 +79,4 @@ The CSS classes used by `ox-html` are documented [here](http://orgmode.org/manua
 4. [thomasf/solarized-css](https://github.com/thomasf/solarized-css)
 5. [org-spec](http://demo.thi.ng/org-spec/)
 6. [Organize Your Life In Plain Text!](http://doc.norang.ca/org-mode.html)
+7. [Org Themes collection](https://olmon.gitlab.io/org-themes/)


### PR DESCRIPTION
Hey! Thanks for making your org css theme open source. Your repo is the second on
the google search results page for 'org css'!

To be fair, I don't know who is borrowing from who, but I came across:

https://olmon.gitlab.io/org-themes/comfy_inline/comfy_inline.html

Which looks to be a building block for your theme as your theme was for my own
CSS. Or it could be the other way around. Either way, the gitlab page serves as
a great resource for the already small org community!

Have a good one,